### PR TITLE
Create a git config with push.default set to current

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,0 +1,2 @@
+[push]
+	default=current


### PR DESCRIPTION
This makes it so VS Code won't warn when pushing a new branch